### PR TITLE
Articles Create Page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,10 @@ import RestaurantIndexPage from "main/pages/Restaurants/RestaurantIndexPage";
 import RestaurantCreatePage from "main/pages/Restaurants/RestaurantCreatePage";
 import RestaurantEditPage from "main/pages/Restaurants/RestaurantEditPage";
 
+import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
+import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
+import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
@@ -58,6 +62,21 @@ function App() {
             <>
               <Route exact path="/restaurants/edit/:id" element={<RestaurantEditPage />} />
               <Route exact path="/restaurants/create" element={<RestaurantCreatePage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/articles" element={<ArticlesIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/articles/edit/:id" element={<ArticlesEditPage />} />
+              <Route exact path="/articles/create" element={<ArticlesCreatePage />} />
             </>
           )
         }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -98,6 +98,7 @@ function App() {
             </>
           )
         } 
+        {
           hasRole(currentUser, "ROLE_ADMIN") && (
             <>
               <Route exact path="/helprequest/edit/:id" element={<HelpRequestEditPage />} />

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -57,6 +57,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 <>
                   <Nav.Link as={Link} to="/restaurants">Restaurants</Nav.Link>
                   <Nav.Link as={Link} to="/ucsbdates">UCSB Dates</Nav.Link>
+                  <Nav.Link as={Link} to="/articles">Articles</Nav.Link>
                   <Nav.Link as={Link} to="/placeholder">Placeholder</Nav.Link>
                 </>
               )

--- a/frontend/src/main/pages/Articles/ArticlesCreatePage.js
+++ b/frontend/src/main/pages/Articles/ArticlesCreatePage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticlesCreatePage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/Articles/ArticlesCreatePage.js
+++ b/frontend/src/main/pages/Articles/ArticlesCreatePage.js
@@ -1,12 +1,49 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import ArticlesForm from "main/components/Articles/ArticlesForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function ArticlesCreatePage() {
+export default function ArticlesCreatePage({storybook=false}) {
 
-  // Stryker disable all : placeholder for future implementation
+  const objectToAxiosParams = (article) => ({
+    url: "/api/articles/post",
+    method: "POST",
+    params: {
+     title: article.title,
+     url: article.url,
+     explanation: article.explanation,
+     email: article.email,
+     dateAdded: article.dateAdded
+    }
+  });
+
+  const onSuccess = (article) => {
+    toast(`New article Created - id: ${article.id} title: ${article.title}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/articles/all"] // mutation makes this key stale so that pages relying on it reload
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/articles" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New Article</h1>
+        <ArticlesForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/Articles/ArticlesEditPage.js
+++ b/frontend/src/main/pages/Articles/ArticlesEditPage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticlesEditPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/Articles/ArticlesIndexPage.js
+++ b/frontend/src/main/pages/Articles/ArticlesIndexPage.js
@@ -1,0 +1,15 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticlesIndexPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p><a href="/placeholder/create">Create</a></p>
+        <p><a href="/placeholder/edit/1">Edit</a></p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/stories/pages/Articles/ArticlesCreatePage.stories.js
+++ b/frontend/src/stories/pages/Articles/ArticlesCreatePage.stories.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage"
+
+export default {
+    title: 'pages/Articles/ArticlesCreatePage',
+    component: ArticlesCreatePage
+};
+
+const Template = () => <ArticlesCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.post('/api/articles/post', (req, res, ctx) => {
+            window.alert("POST: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+}
+
+
+

--- a/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.js
+++ b/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.js
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("ArticlesCreatePage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+       
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ArticlesCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.js
+++ b/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.js
@@ -1,31 +1,48 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
 describe("ArticlesCreatePage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
 
-    const setupUserOnly = () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+    });
 
     const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
-
-        setupUserOnly();
-       
-        // act
+    test("renders without crashing", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -33,11 +50,74 @@ describe("ArticlesCreatePage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
-
-        // assert
-        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
     });
 
+    test("on submit, makes request to backend, and redirects to /articles", async () => {
+
+        const queryClient = new QueryClient();
+        const article = {
+            id: 3,
+            title: "South Coast Deli",
+            url: "www.a.com",
+            explanation: "Sandwiches and Salads",
+            email: "sandwich@gmail.com",
+            dateAdded: "2022-02-02T00:00"
+        };
+
+        axiosMock.onPost("/api/articles/post").reply(202, article);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ArticlesCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByLabelText("Title")).toBeInTheDocument();
+        });
+
+        const titleInput = screen.getByLabelText("Title");
+        expect(titleInput).toBeInTheDocument();
+
+        const urlInput = screen.getByLabelText("Url");
+        expect(urlInput).toBeInTheDocument();
+
+        const explanationInput = screen.getByLabelText("Explanation");
+        expect(explanationInput).toBeInTheDocument();
+
+        const emailInput = screen.getByLabelText("Email");
+        expect(emailInput).toBeInTheDocument();
+
+        const dateInput = screen.getByLabelText("Date (iso format)");
+        expect(dateInput).toBeInTheDocument();
+
+        const createButton = screen.getByText("Create");
+        expect(createButton).toBeInTheDocument();
+
+        fireEvent.change(titleInput, { target: { value: 'South Coast Deli' } })
+        fireEvent.change(urlInput, { target: { value: 'www.a.com' } })
+        fireEvent.change(explanationInput, { target: { value: 'Sandwiches and Salads' } })
+        fireEvent.change(emailInput, { target: { value: 'sandwich@gmail.com' } })
+        fireEvent.change(dateInput, { target: { value: '2022-02-02T00:00' } })
+        fireEvent.click(createButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual({
+            title: "South Coast Deli",
+            url: "www.a.com",
+            explanation: "Sandwiches and Salads",
+            email: "sandwich@gmail.com",
+            dateAdded: "2022-02-02T00:00"
+        });
+
+        // assert - check that the toast was called with the expected message
+        expect(mockToast).toBeCalledWith("New article Created - id: 3 title: South Coast Deli");
+        expect(mockNavigate).toBeCalledWith({ "to": "/articles" });
+
+    });
 });
 
 

--- a/frontend/src/tests/pages/Articles/ArticlesEditPage.test.js
+++ b/frontend/src/tests/pages/Articles/ArticlesEditPage.test.js
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("ArticlesEditPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ArticlesEditPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/Articles/ArticlesIndexPage.test.js
+++ b/frontend/src/tests/pages/Articles/ArticlesIndexPage.test.js
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("ArticlesIndexPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <ArticlesIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
+        expect(screen.getByText("Create")).toBeInTheDocument();
+        expect(screen.getByText("Edit")).toBeInTheDocument();
+    });
+
+});
+
+


### PR DESCRIPTION
Implemented Articles create page.

Navigate to /articles/create :
<img width="1345" alt="Screen Shot 2024-05-11 at 2 59 42 PM" src="https://github.com/ucsb-cs156-s24/team03-s24-4pm-4/assets/46095500/1a77a0e2-481a-4557-9616-69cf0aeb0065">

Add in fields:
<img width="1382" alt="Screen Shot 2024-05-11 at 3 00 38 PM" src="https://github.com/ucsb-cs156-s24/team03-s24-4pm-4/assets/46095500/dc74e652-6383-4f06-81be-205c7f1f8d8e">

Click create and the page will redirect to the index page with the message confirming creation:
<img width="1433" alt="Screen Shot 2024-05-11 at 3 01 31 PM" src="https://github.com/ucsb-cs156-s24/team03-s24-4pm-4/assets/46095500/e24f0cc7-c286-4a88-a0ad-d5d7be34e88e">

Inputting wrong fields gives correct error messages and stays on the page:
<img width="1369" alt="Screen Shot 2024-05-11 at 3 02 36 PM" src="https://github.com/ucsb-cs156-s24/team03-s24-4pm-4/assets/46095500/53077cae-7d8f-4f80-89f4-0a5f95913f69">
<img width="1359" alt="Screen Shot 2024-05-11 at 3 03 04 PM" src="https://github.com/ucsb-cs156-s24/team03-s24-4pm-4/assets/46095500/a9876288-c64a-4a7f-b777-a14ad5e53785">

Checking database through swagger shows us the article we created:
<img width="802" alt="Screen Shot 2024-05-11 at 3 04 00 PM" src="https://github.com/ucsb-cs156-s24/team03-s24-4pm-4/assets/46095500/cfe35cf9-93ad-4b08-9022-68bd2793cff0">


Closes #59 


