### PR TITLE
Add MenuItemReview Edit Page and Tests 

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,6 +15,10 @@ import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
+import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
+
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -73,6 +77,21 @@ function App() {
             <>
               <Route exact path="/placeholder/edit/:id" element={<PlaceholderEditPage />} />
               <Route exact path="/placeholder/create" element={<PlaceholderCreatePage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/menuitemreview" element={<MenuItemReviewIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/menuitemreview/edit/:id" element={<MenuItemReviewEditPage />} />
+              <Route exact path="/menuitemreview/create" element={<MenuItemReviewCreatePage />} />
             </>
           )
         }

--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.js
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewForm.js
@@ -108,16 +108,16 @@ function MenuItemReviewForm({ initialContents, submitAction, buttonLabel = "Crea
             <Row>
                 <Col>
                     <Form.Group className="mb-3">
-                        <Form.Label htmlFor="localDateTime">Date (iso format)</Form.Label>
+                        <Form.Label htmlFor="dateReviewed">Date (iso format)</Form.Label>
                         <Form.Control
-                            data-testid="MenuItemReviewForm-localDateTime"
-                            id="localDateTime"
+                            data-testid="MenuItemReviewForm-dateReviewed"
+                            id="dateReviewed"
                             type="datetime-local"
-                            isInvalid={Boolean(errors.localDateTime)}
-                            {...register("localDateTime", { required: true, pattern: isodate_regex })}
+                            isInvalid={Boolean(errors.dateReviewed)}
+                            {...register("dateReviewed", { required: true, pattern: isodate_regex })}
                         />
                         <Form.Control.Feedback type="invalid">
-                            {errors.localDateTime && 'LocalDateTime is required.'}
+                            {errors.dateReviewed && 'Date Reviewed is required.'}
                         </Form.Control.Feedback>
                     </Form.Group>
                 </Col>

--- a/frontend/src/main/components/MenuItemReview/MenuItemReviewTable.js
+++ b/frontend/src/main/components/MenuItemReview/MenuItemReviewTable.js
@@ -1,0 +1,67 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/menuItemReviewUtils"
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function MenuItemReviewTable({ reviews, currentUser }) {
+
+    const navigate = useNavigate();
+
+    const editCallback = (cell) => {
+        navigate(`/menuitemreview/edit/${cell.row.values.id}`)
+    }
+
+    // Stryker disable all : hard to test for query caching
+
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/menuitemreview/all"]
+    );
+    // Stryker restore all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id', // accessor is the "key" in the data
+        },
+        {
+            Header: 'Item Id',
+            accessor: 'itemId',
+        },
+        {
+            Header: 'Email',
+            accessor: 'reviewerEmail',
+        },
+        {
+            Header: 'Stars',
+            accessor: 'stars',
+        },
+        {
+            Header: 'Date Reviewed',
+            accessor: 'dateReviewed',
+        },
+        {
+            Header: 'Comments',
+            accessor: 'comments',
+        }
+    ];
+
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        columns.push(ButtonColumn("Edit", "primary", editCallback, "MenuItemReviewTable"));
+        columns.push(ButtonColumn("Delete", "danger", deleteCallback, "MenuItemReviewTable"));
+    } 
+
+    return <OurTable
+        data={reviews}
+        columns={columns}
+        testid={"MenuItemReviewTable"}
+    />;
+};

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -58,6 +58,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                   <Nav.Link as={Link} to="/restaurants">Restaurants</Nav.Link>
                   <Nav.Link as={Link} to="/ucsbdates">UCSB Dates</Nav.Link>
                   <Nav.Link as={Link} to="/placeholder">Placeholder</Nav.Link>
+                  <Nav.Link as={Link} to="/menuitemreview">MenuItemReview</Nav.Link>
                 </>
               )
             }

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewCreatePage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewCreatePage.js
@@ -1,0 +1,52 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function MenuItemReviewCreatePage({storybook=false}) {
+
+  const objectToAxiosParams = (menuItemReview) => ({
+    url: "/api/menuitemreview/post",
+    method: "POST",
+    params: {
+        itemId: menuItemReview.itemId,
+        reviewerEmail: menuItemReview.reviewerEmail,
+        stars: menuItemReview.stars,
+        comments: menuItemReview.comments,
+        dateReviewed: menuItemReview.dateReviewed,
+    }
+  });
+
+  const onSuccess = (menuItemReview) => {
+    toast(`New menuItemReview Created - id: ${menuItemReview.id} itemId: ${menuItemReview.itemId}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/menuitemreview/all"]
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/menuitemreview" />
+  }
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create New MenuItemReview</h1>
+
+        <MenuItemReviewForm submitAction={onSubmit} />
+
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewEditPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewEditPage.js
@@ -1,12 +1,70 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function MenuItemReviewEditPage() {
+export default function MenuItemReviewEditPage({storybook=false}) {
+  let { id } = useParams();
 
-  // Stryker disable all : placeholder for future implementation
+  const { data: menuItemReview, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/menuitemreview?id=${id}`],
+      { // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/menuitemreview`,
+        params: {
+          id
+        }
+      }
+    );
+
+
+  const objectToAxiosPutParams = (menuItemReview) => ({
+    url: "/api/menuitemreview",
+    method: "PUT",
+    params: {
+      id: menuItemReview.id,
+    },
+    data: {
+      itemId: menuItemReview.itemId,
+      reviewerEmail: menuItemReview.reviewerEmail,
+      stars: menuItemReview.stars,
+      dateReviewed: menuItemReview.dateReviewed,
+      comments: menuItemReview.comments
+    }
+  });
+
+  const onSuccess = (menuItemReview) => {
+    toast(`MenuItemReview Updated - id: ${menuItemReview.id} itemId: ${menuItemReview.itemId}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/menuitemreview?id=${id}`]
+  );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/menuitemreview" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit MenuItemReview</h1>
+        {
+          menuItemReview && <MenuItemReviewForm initialContents={menuItemReview} submitAction={onSubmit} buttonLabel="Update" />
+        }
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
@@ -1,0 +1,15 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemReviewIndexPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p><a href="/menuitemreview/create">Create</a></p>
+        <p><a href="/menuitemreview/edit/1">Edit</a></p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
+++ b/frontend/src/main/pages/MenuItemReview/MenuItemReviewIndexPage.js
@@ -1,14 +1,43 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend';
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import MenuItemReviewTable from 'main/components/MenuItemReview/MenuItemReviewTable';
+import { Button } from 'react-bootstrap';
+import { useCurrentUser , hasRole} from 'main/utils/currentUser';
 
-export default function MenuItemReviewIndexPage() {
+export default function MneuItemReviewIndexPage() {
 
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        return (
+            <Button
+                variant="primary"
+                href="/menuitemreview/create"
+                style={{ float: "right" }}
+            >
+                Create MenuItemReview
+            </Button>
+        )
+    } 
+  }
+  
+  const { data: reviews, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/menuitemreview/all"],
+      { method: "GET", url: "/api/menuitemreview/all" },
+      []
+    );
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p><a href="/menuitemreview/create">Create</a></p>
-        <p><a href="/menuitemreview/edit/1">Edit</a></p>
+        {createButton()}
+        <h1>MenuItemReview</h1>
+        <MenuItemReviewTable reviews={reviews} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/utils/menuItemReviewUtils.js
+++ b/frontend/src/main/utils/menuItemReviewUtils.js
@@ -1,0 +1,17 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+    console.log(message);
+    toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/menuitemreview",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}
+

--- a/frontend/src/stories/components/MenuItemReview/MenuItemReviewForm.stories.js
+++ b/frontend/src/stories/components/MenuItemReview/MenuItemReviewForm.stories.js
@@ -3,7 +3,7 @@ import MenuItemReviewForm from "main/components/MenuItemReview/MenuItemReviewFor
 import { menuItemReviewFixtures } from 'fixtures/menuItemReviewFixtures';
 
 export default {
-    title: 'components/MenuItemReviewForm/MenuItemReviewForm',
+    title: 'components/MenuItemReview/MenuItemReviewForm',
     component: MenuItemReviewForm
 };
 

--- a/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.js
+++ b/frontend/src/stories/components/MenuItemReview/MenuItemReviewTable.stories.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import MenuItemReviewTable from "main/components/MenuItemReview/MenuItemReviewTable";
+import { menuItemReviewFixtures } from 'fixtures/menuItemReviewFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { rest } from "msw";
+
+export default {
+    title: 'components/MenuItemReview/MenuItemReviewTable',
+    component: MenuItemReviewTable
+};
+
+const Template = (args) => {
+    return (
+        <MenuItemReviewTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    reviews: []
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+    reviews: menuItemReviewFixtures.threeReviews,
+    currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+    reviews: menuItemReviewFixtures.threeReviews,
+    currentUser: currentUserFixtures.adminUser,
+}
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.delete('/api/menuitemreview', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+};
+

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.js
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewForm.test.js
@@ -47,12 +47,12 @@ describe("MenuItemReviewForm tests", () => {
         );
         await screen.findByTestId("MenuItemReviewForm-itemId");
         const itemIdField = screen.getByTestId("MenuItemReviewForm-itemId");
-        const localDateTimeField = screen.getByTestId("MenuItemReviewForm-localDateTime");
+        const dateReviewedField = screen.getByTestId("MenuItemReviewForm-dateReviewed");
         const starsField = screen.getByTestId("MenuItemReviewForm-stars");
         const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
 
         fireEvent.change(itemIdField, { target: { value: 'bad-input' } });
-        fireEvent.change(localDateTimeField, { target: { value: 'bad-input' } });
+        fireEvent.change(dateReviewedField, { target: { value: 'bad-input' } });
         fireEvent.change(starsField, { target: { value: 'bad-input' } });
         fireEvent.click(submitButton);
 
@@ -81,7 +81,7 @@ describe("MenuItemReviewForm tests", () => {
 
         await screen.findByText(/Item Id is required./);
         expect(screen.getByText(/Reviewer Email is required./)).toBeInTheDocument();
-        expect(screen.getByText(/LocalDateTime is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Date Reviewed is required./)).toBeInTheDocument();
         expect(screen.getByText(/Stars is required./)).toBeInTheDocument();
         expect(screen.getByText(/Comments is required./)).toBeInTheDocument();
 
@@ -102,14 +102,14 @@ describe("MenuItemReviewForm tests", () => {
         const itemIdField = screen.getByTestId("MenuItemReviewForm-itemId");
         const reviewerEmailField = screen.getByTestId("MenuItemReviewForm-reviewerEmail");
         const starsField = screen.getByTestId("MenuItemReviewForm-stars");
-        const localDateTimeField = screen.getByTestId("MenuItemReviewForm-localDateTime");
+        const dateReviewedField = screen.getByTestId("MenuItemReviewForm-dateReviewed");
         const commentsField = screen.getByTestId("MenuItemReviewForm-comments");
         const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
 
         fireEvent.change(itemIdField, { target: { value: '1' } });
         fireEvent.change(reviewerEmailField, { target: { value: 'test@gmail.com' } });
         fireEvent.change(starsField, { target: { value: '3' } });
-        fireEvent.change(localDateTimeField, { target: { value: '2022-01-02T12:00' } });
+        fireEvent.change(dateReviewedField, { target: { value: '2022-01-02T12:00' } });
         fireEvent.change(commentsField, { target: { value: 'This is a test review' } });
         fireEvent.click(submitButton);
 
@@ -119,7 +119,7 @@ describe("MenuItemReviewForm tests", () => {
         expect(screen.queryByText(/Reviewer Email is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Stars is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Stars must be a number from 1 to 5./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/LocalDateTime is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Date Reviewed is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Comments is required./)).not.toBeInTheDocument();
 
 

--- a/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.js
+++ b/frontend/src/tests/components/MenuItemReview/MenuItemReviewTable.test.js
@@ -1,0 +1,145 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
+import MenuItemReviewTable from "main/components/MenuItemReview/MenuItemReviewTable"
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("MenuItemReview tests", () => {
+  const queryClient = new QueryClient();
+  const expectedHeaders = ["id", "Item Id", "Email", "Stars", "Date Reviewed", "Comments"];
+  const expectedFields = ["id", "itemId", "reviewerEmail", "stars", "dateReviewed", "comments"];
+  const testId = "MenuItemReviewTable";
+
+  test("Has the expected column headers and content for ordinary user", () => {
+
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable reviews={menuItemReviewFixtures.threeReviews} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+    const editButton = screen.queryByTestId(`${testId}-cell-row-0-col-Edit`);
+    expect(editButton).not.toBeInTheDocument();
+
+    const deleteButton = screen.queryByTestId(`${testId}-cell-row-0-col-Delete`);
+    expect(deleteButton).not.toBeInTheDocument();
+
+  });
+
+  test("Has the expected colum headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable reviews={menuItemReviewFixtures.threeReviews} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+
+  test("Edit button navigates to the edit page", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemReviewTable reviews={menuItemReviewFixtures.threeReviews} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-itemId`)).toHaveTextContent("1");
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+
+    // act - click the edit button
+    fireEvent.click(editButton);
+
+    // assert - check that the navigate function was called with the expected path
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/menuitemreview/edit/1'));
+
+  });
+
+  test("Delete button calls delete callback", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+        <MenuItemReviewTable reviews={menuItemReviewFixtures.threeReviews} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-itemId`)).toHaveTextContent("1");
+
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+
+    // act - click the delete button
+    fireEvent.click(deleteButton);
+  });
+
+});
+

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
+import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
@@ -8,7 +8,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-describe("PlaceholderCreatePage tests", () => {
+describe("MenuItemReviewCreatePage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
 
@@ -29,7 +29,7 @@ describe("PlaceholderCreatePage tests", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
-                    <PlaceholderCreatePage />
+                    <MenuItemReviewCreatePage />
                 </MemoryRouter>
             </QueryClientProvider>
         );

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("PlaceholderCreatePage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+       
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlaceholderCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewCreatePage.test.js
@@ -1,0 +1,114 @@
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
+import MenuItemReviewCreatePage from "main/pages/MenuItemReview/MenuItemReviewCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("MenuItemReviewCreatePage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    });
+
+    test("renders without crashing", () => {
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+
+        const queryClient = new QueryClient();
+        const menuItemReview = {
+            id: 1,
+            itemId: 1,
+            reviewerEmail: "test@gmail.com",
+            stars: 5,
+            dateReviewed: "2022-01-02T12:00:00",
+            comments: "This is a test comment"
+        }
+
+        axiosMock.onPost("/api/menuitemreview/post").reply( 202, menuItemReview );
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId("MenuItemReviewForm-itemId")).toBeInTheDocument();
+        });
+
+        const itemIdField = screen.getByTestId("MenuItemReviewForm-itemId");
+        const reviewerEmailField = screen.getByTestId("MenuItemReviewForm-reviewerEmail");
+        const starsField = screen.getByTestId("MenuItemReviewForm-stars");
+        const dateReviewedField = screen.getByTestId("MenuItemReviewForm-dateReviewed");
+        const commentsField = screen.getByTestId("MenuItemReviewForm-comments");
+        const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
+
+        fireEvent.change(itemIdField, { target: { value: '10' } });
+        fireEvent.change(reviewerEmailField, { target: { value: 'updated@gmail.com' } });
+        fireEvent.change(starsField, { target: { value: '4' } });
+        fireEvent.change(dateReviewedField, { target: { value: '2024-01-02T12:00' } });
+        fireEvent.change(commentsField, { target: { value: 'Updated' } });
+
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual(
+            {
+            "itemId": "10",
+            "reviewerEmail": "updated@gmail.com",
+            "stars": "4",
+            "dateReviewed": "2024-01-02T12:00",
+            "comments": "Updated"
+        });
+
+        expect(mockToast).toBeCalledWith("New menuItemReview Created - id: 1 itemId: 1");
+        expect(mockNavigate).toBeCalledWith({ "to": "/menuitemreview" });
+    });
+
+
+});
+
+

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
+import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
@@ -9,7 +9,7 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 
-describe("PlaceholderEditPage tests", () => {
+describe("MenuItemReviewEditPage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
 
@@ -30,7 +30,7 @@ describe("PlaceholderEditPage tests", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
-                    <PlaceholderEditPage />
+                    <MenuItemReviewEditPage />
                 </MemoryRouter>
             </QueryClientProvider>
         );

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("PlaceholderEditPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlaceholderEditPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewEditPage.test.js
@@ -1,44 +1,189 @@
-import { render, screen } from "@testing-library/react";
-import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import MenuItemReviewEditPage from "main/pages/MenuItemReview/MenuItemReviewEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 1
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
 describe("MenuItemReviewEditPage tests", () => {
 
-    const axiosMock = new AxiosMockAdapter(axios);
+    describe("when the backend doesn't return data", () => {
 
-    const setupUserOnly = () => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+        const axiosMock = new AxiosMockAdapter(axios);
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/ucsbdates", { params: { id: 1 } }).timeout();
+        });
 
-        setupUserOnly();
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
 
-        // act
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <MenuItemReviewEditPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
+            const restoreConsole = mockConsole();
 
-        // assert
-        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <MenuItemReviewEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await screen.findByText("Edit MenuItemReview");
+            expect(screen.queryByTestId("MenuItemReviewForm-itemId")).not.toBeInTheDocument();
+            restoreConsole();
+        });
     });
 
+    describe("tests where backend is working normally", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/menuitemreview", { params: { id: 1 } }).reply(200, {
+                id: 1,
+                itemId: 101,
+                reviewerEmail: "test@gmail.com",
+                stars: 4,
+                dateReviewed: "2022-01-02T12:00:00",
+                comments: "Great!"
+            });
+            axiosMock.onPut('/api/menuitemreview').reply(200, {
+                id: "1",
+                itemId: "102",
+                reviewerEmail: "testnew@gmail.com",
+                stars: "5",
+                dateReviewed: "2022-01-12T12:00:00",
+                comments: "awesome!"
+            });
+        });
+
+        const queryClient = new QueryClient();
+        test("renders without crashing", () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <MenuItemReviewEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        });
+
+        test("Is populated with the data provided", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <MenuItemReviewEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("MenuItemReviewForm-itemId");
+
+            const idField = screen.getByTestId("MenuItemReviewForm-id")
+            const itemIdField = screen.getByTestId("MenuItemReviewForm-itemId");
+            const reviewerEmailField = screen.getByTestId("MenuItemReviewForm-reviewerEmail");
+            const starsField = screen.getByTestId("MenuItemReviewForm-stars");
+            const dateReviewedField = screen.getByTestId("MenuItemReviewForm-dateReviewed");
+            const commentsField = screen.getByTestId("MenuItemReviewForm-comments");
+            const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
+    
+            expect(idField).toHaveValue("1")
+            expect(itemIdField).toHaveValue("101")
+            expect(reviewerEmailField).toHaveValue("test@gmail.com")
+            expect(starsField).toHaveValue("4")
+            expect(dateReviewedField).toHaveValue("2022-01-02T12:00")
+            expect(commentsField).toHaveValue("Great!")
+            expect(submitButton).toBeInTheDocument();
+
+        });
+
+        test("Changes when you click Update", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <MenuItemReviewEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("MenuItemReviewForm-itemId");
+
+            const itemIdField = screen.getByTestId("MenuItemReviewForm-itemId");
+            const reviewerEmailField = screen.getByTestId("MenuItemReviewForm-reviewerEmail");
+            const starsField = screen.getByTestId("MenuItemReviewForm-stars");
+            const dateReviewedField = screen.getByTestId("MenuItemReviewForm-dateReviewed");
+            const commentsField = screen.getByTestId("MenuItemReviewForm-comments");
+            const submitButton = screen.getByTestId("MenuItemReviewForm-submit");
+
+            expect(itemIdField).toHaveValue("101");
+            expect(reviewerEmailField).toHaveValue("test@gmail.com");
+            expect(starsField).toHaveValue("4");
+            expect(dateReviewedField).toHaveValue("2022-01-02T12:00");
+            expect(commentsField).toHaveValue("Great!");
+            expect(submitButton).toBeInTheDocument();
+
+    
+            fireEvent.change(itemIdField, { target: { value: '10' } });
+            fireEvent.change(reviewerEmailField, { target: { value: 'test@gmail.com' } });
+            fireEvent.change(starsField, { target: { value: '4' } });
+            fireEvent.change(dateReviewedField, { target: { value: '2024-01-02T12:00' } });
+            fireEvent.change(commentsField, { target: { value: 'Updated' } });
+
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith("MenuItemReview Updated - id: 1 itemId: 102");
+            expect(mockNavigate).toBeCalledWith({ "to": "/menuitemreview" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ id: 1 });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                itemId: "10",
+                reviewerEmail: "test@gmail.com",
+                stars: 4,
+                dateReviewed: "2024-01-02T12:00",
+                comments: "Updated"
+            })); // posted object
+
+        });
+    });
 });
 
 

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
@@ -9,7 +9,7 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 
-describe("PlaceholderIndexPage tests", () => {
+describe("MenuItemReviewIndexPage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
 
@@ -30,7 +30,7 @@ describe("PlaceholderIndexPage tests", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
-                    <PlaceholderIndexPage />
+                    <MenuItemReviewIndexPage />
                 </MemoryRouter>
             </QueryClientProvider>
         );

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("PlaceholderIndexPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlaceholderIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
+        expect(screen.getByText("Create")).toBeInTheDocument();
+        expect(screen.getByText("Edit")).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
+++ b/frontend/src/tests/pages/MenuItemReview/MenuItemReviewIndexPage.test.js
@@ -1,17 +1,31 @@
-import { render, screen } from "@testing-library/react";
-import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import MenuItemReviewIndexPage from "main/pages/MenuItemReview/MenuItemReviewIndexPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { menuItemReviewFixtures } from "fixtures/menuItemReviewFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
 
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
 
 describe("MenuItemReviewIndexPage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "MenuItemReviewTable";
 
     const setupUserOnly = () => {
         axiosMock.reset();
@@ -20,11 +34,18 @@ describe("MenuItemReviewIndexPage tests", () => {
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     };
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
 
-        setupUserOnly();
+    test("Renders with Create Button for admin user", async () => {
+        // arrange
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/menuitemreview/all").reply(200, []);
 
         // act
         render(
@@ -36,11 +57,97 @@ describe("MenuItemReviewIndexPage tests", () => {
         );
 
         // assert
-        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
-        expect(screen.getByText("Create")).toBeInTheDocument();
-        expect(screen.getByText("Edit")).toBeInTheDocument();
+        await waitFor( ()=>{
+            expect(screen.getByText(/Create MenuItemReview/)).toBeInTheDocument();
+        });
+        const button = screen.getByText(/Create MenuItemReview/);
+        expect(button).toHaveAttribute("href", "/menuitemreview/create");
+        expect(button).toHaveAttribute("style", "float: right;");
+    });
+
+    test("renders three reviews correctly for regular user", async () => {
+        
+        // arrange
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/menuitemreview/all").reply(200, menuItemReviewFixtures.threeReviews);
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+        // assert that the Create button is not present when user isn't an admin
+        expect(screen.queryByText(/Create MenuItemReview/)).not.toBeInTheDocument();
+
+    });
+
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        // arrange
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/menuitemreview/all").timeout();
+        const restoreConsole = mockConsole();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/menuitemreview/all");
+        restoreConsole();
+
+        expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+
+    test("what happens when you click delete, admin", async () => {
+        // arrange
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/menuitemreview/all").reply(200, menuItemReviewFixtures.threeReviews);
+        axiosMock.onDelete("/api/menuitemreview").reply(200, "MenuItemReview with id 1 was deleted");
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <MenuItemReviewIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+
+        // act
+        fireEvent.click(deleteButton);
+
+        // assert
+        await waitFor(() => { expect(mockToast).toBeCalledWith("MenuItemReview with id 1 was deleted") });
+
     });
 
 });
-
-

--- a/frontend/src/tests/utils/menuItemReviewUtils.test.js
+++ b/frontend/src/tests/utils/menuItemReviewUtils.test.js
@@ -1,0 +1,53 @@
+import { onDeleteSuccess, cellToAxiosParamsDelete } from "main/utils/menuItemReviewUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("MenuItemReviewsUtils", () => {
+
+    describe("onDeleteSuccess", () => {
+
+        test("It puts the message on console.log and in a toast", () => {
+            // arrange
+            const restoreConsole = mockConsole();
+
+            // act
+            onDeleteSuccess("abc");
+
+            // assert
+            expect(mockToast).toHaveBeenCalledWith("abc");
+            expect(console.log).toHaveBeenCalled();
+            const message = console.log.mock.calls[0][0];
+            expect(message).toMatch("abc");
+
+            restoreConsole();
+        });
+
+    });
+    describe("cellToAxiosParamsDelete", () => {
+
+        test("It returns the correct params", () => {
+            // arrange
+            const cell = { row: { values: { id: 1 } } };
+
+            // act
+            const result = cellToAxiosParamsDelete(cell);
+
+            // assert
+            expect(result).toEqual({
+                url: "/api/menuitemreview",
+                method: "DELETE",
+                params: { id: 1 }
+            });
+        });
+
+    });
+});


### PR DESCRIPTION
Adding MenuItemReview Edit Page and Tests 

Navigate to /menuitemreview then click the edit button on any item

<img width="1421" alt="Screenshot 2024-05-11 at 10 04 04 PM" src="https://github.com/ucsb-cs156-s24/team03-s24-4pm-4/assets/17103790/7af99e66-b2b2-4117-9a64-fbb2cf6033d5">

It should take you to an edit item form where you can change the fields:

<img width="1421" alt="Screenshot 2024-05-11 at 10 04 26 PM" src="https://github.com/ucsb-cs156-s24/team03-s24-4pm-4/assets/17103790/aab22100-e558-42d8-8831-d44038a733a6">

Update the fields and hit "Update". There should be a popup saying item updated and the table should contain the new information:

<img width="1419" alt="Screenshot 2024-05-11 at 10 04 51 PM" src="https://github.com/ucsb-cs156-s24/team03-s24-4pm-4/assets/17103790/6f1294d7-57ee-4e7c-9538-c99da3fb374b">

Closes #43 
