### PR TITLE
Added RecRequest create page

### DIFF
--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.js
@@ -1,12 +1,52 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import RecommendationRequestForm from "main/components/RecommendationRequest/RecommendationRequestForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function RecommendationRequestCreatePage() {
+export default function RecommendationRequestCreatePage({storybook=false}) {
 
-  // Stryker disable all : placeholder for future implementation
+  const objectToAxiosParams = (recommendationrequest) => ({
+    url: "/api/recommendationrequests/post",
+    method: "POST",
+    params: {
+      requesterEmail: recommendationrequest.requesterEmail,
+      professorEmail: recommendationrequest.professorEmail,
+      explanation: recommendationrequest.explanation,
+      dateRequested: recommendationrequest.dateRequested,
+      dateNeeded: recommendationrequest.dateNeeded,
+      done: recommendationrequest.done
+    }
+  });
+
+  const onSuccess = (recommendationrequest) => {
+    toast(`New RecommendationRequest Created - id: ${recommendationrequest.id} requesterEmail: ${recommendationrequest.requesterEmail}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/recommendationrequests/all"]
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/recommendationrequest" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New RecommendationRequest</h1>
+
+        <RecommendationRequestForm submitAction={onSubmit} />
+
       </div>
     </BasicLayout>
   )

--- a/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestCreatePage.stories.js
+++ b/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestCreatePage.stories.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import RecommendationRequestCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
+
+export default {
+    title: 'pages/RecommendationRequest/RecommendationRequestCreatePage',
+    component: RecommendationRequestCreatePage
+};
+
+const Template = () => <RecommendationRequestCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.post('/api/RecommendationRequest/post', (req, res, ctx) => {
+            window.alert("POST: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+}

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
 import RecommendationRequestCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -8,24 +8,63 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
 describe("RecommendationRequestCreatePage tests", () => {
 
-    const axiosMock = new AxiosMockAdapter(axios);
+    const axiosMock =new AxiosMockAdapter(axios);
 
-    const setupUserOnly = () => {
+    beforeEach(() => {
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+    });
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+    test("renders without crashing", () => {
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationRequestCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
 
-        setupUserOnly();
-       
-        // act
+    test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+
+        const queryClient = new QueryClient();
+        const recommendationRequest = {
+            id: 17,
+            requesterEmail: "test@ucsb.edu",
+            professorEmail: "test@ucsb.edu",
+            explanation: "na",
+            dateRequested: "2022-02-02T00:00",
+            dateNeeded: "2022-03-02T00:00",
+            done: "false"
+        };
+
+        axiosMock.onPost("/api/recommendationrequests/post").reply( 202, recommendationRequest );
+
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -34,10 +73,44 @@ describe("RecommendationRequestCreatePage tests", () => {
             </QueryClientProvider>
         );
 
-        // assert
-        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByTestId("RecommendationRequestForm-requesterEmail")).toBeInTheDocument();
+        });
+
+        const requesterEmailField = screen.getByTestId("RecommendationRequestForm-requesterEmail");
+        const professorEmailField = screen.getByTestId("RecommendationRequestForm-professorEmail");
+        const explanationField = screen.getByTestId("RecommendationRequestForm-explanation");
+        const dateRequestedField = screen.getByTestId("RecommendationRequestForm-dateRequested");
+        const dateNeededField = screen.getByTestId("RecommendationRequestForm-dateNeeded");
+        const doneField = screen.getByTestId("RecommendationRequestForm-done");
+        const submitButton = screen.getByTestId("RecommendationRequestForm-submit");
+
+        fireEvent.change(requesterEmailField, { target: { value: 'test@ucsb.edu' } });
+        fireEvent.change(professorEmailField, { target: { value: 'test@ucsb.edu' } });
+        fireEvent.change(explanationField, { target: { value: 'na' } });
+        fireEvent.change(dateRequestedField, { target: { value: '2022-02-02T00:00' } });
+        fireEvent.change(dateNeededField, { target: { value: '2022-03-02T00:00' } });
+        fireEvent.change(doneField, { target: { value: 'false' } });
+
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual(
+            {
+            "requesterEmail": "test@ucsb.edu",
+            "professorEmail": "test@ucsb.edu",
+            "explanation": "na",
+            "dateRequested": "2022-02-02T00:00",
+            "dateNeeded": "2022-03-02T00:00",
+            "done": "false"
+        });
+
+        expect(mockToast).toBeCalledWith("New RecommendationRequest Created - id: 17 requesterEmail: test@ucsb.edu");
+        expect(mockNavigate).toBeCalledWith({ "to": "/recommendationrequest" });
     });
 
+
 });
-
-


### PR DESCRIPTION
In this PR, added the implementation for recommendation request create page and tests. Ran tests, coverage, and mutation testing passing all 100%. 

To test go to swagger and click on the create page that shows up as this: 
<img width="1436" alt="p3" src="https://github.com/ucsb-cs156-s24/team03-s24-4pm-4/assets/122652186/338b1b20-3451-4c83-8ef8-92fa37d2c858">

If submitted valid data will give a creation message and will show up on swagger. If not it will give an error.

Closes #31 